### PR TITLE
javadoc fix to Obfuscator.unobfuscate

### DIFF
--- a/lvl_library/src/main/java/com/google/android/vending/licensing/Obfuscator.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/Obfuscator.java
@@ -39,9 +39,9 @@ public interface Obfuscator {
     /**
      * Undo the transformation applied to data by the obfuscate() method.
      *
-     * @param original The data that is to be obfuscated.
-     * @param key The key for the data that is to be obfuscated.
-     * @return A transformed version of the original data.
+     * @param obfuscated The data that is to be un-obfuscated.
+     * @param key The key for the data that is to be un-obfuscated.
+     * @return The original data transformed by the obfuscate() method.
      * @throws ValidationException Optionally thrown if a data integrity check fails.
      */
     String unobfuscate(String obfuscated, String key) throws ValidationException;


### PR DESCRIPTION
docs(Obfuscator.unobfuscate): fix copy-paste javadoc error

The javadoc comments for Obfuscator.unobfuscate were copy-pasted from Obfuscator.obfuscate.  First parameter had the incorrect name.  Other parameter descriptions were incorrect.