### PR TITLE
Update Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Tue Aug 28 11:44:22 AEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/lvl_library/build.gradle
+++ b/lvl_library/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 4

--- a/lvl_sample/build.gradle
+++ b/lvl_sample/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.example.google.play.licensing"
@@ -22,6 +21,6 @@ android {
 }
 
 dependencies {
-    compile project(':lvl_library')
-    androidTestCompile 'com.android.support.test:runner:0.5'
+    implementation project(':lvl_library')
+    androidTestImplementation 'com.android.support.test:runner:0.5'
 }


### PR DESCRIPTION
Updating Gradle to the latest version and removing the `buildToolsVersion`.

There is now a default build tools version packed into a each Gradle version, so it doesn’t need to be specified, and it it is a warning is thrown.