### PR TITLE
Remove min and target SDK versions from manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 

--- a/lvl_library/build.gradle
+++ b/lvl_library/build.gradle
@@ -4,6 +4,7 @@ android {
     compileSdkVersion 23
 
     defaultConfig {
+        // Devices >= 3 have a version of Android Market that supports licensing.
         minSdkVersion 4
         targetSdkVersion 23
     }

--- a/lvl_library/src/main/AndroidManifest.xml
+++ b/lvl_library/src/main/AndroidManifest.xml
@@ -17,8 +17,6 @@
     package="com.google.android.vending.licensing"
     android:versionCode="2"
     android:versionName="1.5">
-    <!-- Devices >= 3 have version of Android Market that supports licensing. -->
-    <uses-sdk android:minSdkVersion="4" android:targetSdkVersion="23" />
     <!-- Required permission to check licensing. -->
     <uses-permission android:name="com.android.vending.CHECK_LICENSE" />
 </manifest>


### PR DESCRIPTION
Gradle is complaining that these versions are in the Android Manifest. They are already in the Gradle file so it is safe to remove them from here.

Also bumped the Gradle version.