### PR TITLE
Update the LVL to handle another extra being returned by the server

### DIFF
--- a/lvl_library/src/main/java/com/google/android/vending/licensing/APKExpansionPolicy.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/APKExpansionPolicy.java
@@ -33,8 +33,8 @@ import java.util.Vector;
 /**
  * Default policy. All policy decisions are based off of response data received
  * from the licensing service. Specifically, the licensing server sends the
- * following information: response validity period, error retry period, and
- * error retry count.
+ * following information: response validity period, error retry period,
+ * error retry count and a URL for restoring app access in unlicensed cases.
  * <p>
  * These values will vary based on the the way the application is configured in
  * the Google Play publishing console, such as whether the application is
@@ -53,6 +53,7 @@ public class APKExpansionPolicy implements Policy {
     private static final String PREF_RETRY_UNTIL = "retryUntil";
     private static final String PREF_MAX_RETRIES = "maxRetries";
     private static final String PREF_RETRY_COUNT = "retryCount";
+    private static final String PREF_LICENSING_URL = "licensingUrl";
     private static final String DEFAULT_VALIDITY_TIMESTAMP = "0";
     private static final String DEFAULT_RETRY_UNTIL = "0";
     private static final String DEFAULT_MAX_RETRIES = "0";
@@ -66,6 +67,7 @@ public class APKExpansionPolicy implements Policy {
     private long mRetryCount;
     private long mLastResponseTime = 0;
     private int mLastResponse;
+    private String mLicensingUrl;
     private PreferenceObfuscator mPreferences;
     private Vector<String> mExpansionURLs = new Vector<String>();
     private Vector<String> mExpansionFileNames = new Vector<String>();
@@ -94,6 +96,7 @@ public class APKExpansionPolicy implements Policy {
         mRetryUntil = Long.parseLong(mPreferences.getString(PREF_RETRY_UNTIL, DEFAULT_RETRY_UNTIL));
         mMaxRetries = Long.parseLong(mPreferences.getString(PREF_MAX_RETRIES, DEFAULT_MAX_RETRIES));
         mRetryCount = Long.parseLong(mPreferences.getString(PREF_RETRY_COUNT, DEFAULT_RETRY_COUNT));
+        mLicensingUrl = mPreferences.getString(PREF_LICENSING_URL, null);
     }
 
     /**
@@ -119,6 +122,8 @@ public class APKExpansionPolicy implements Policy {
      * until
      * <li>GT: the timestamp that the client should ignore retry errors until
      * <li>GR: the number of retry errors that the client should ignore
+     * <li>LU: a deep link URL that can enable access for unlicensed apps (e.g.
+     * buy app on the Play Store)
      * </ul>
      *
      * @param response the result from validating the server response
@@ -134,9 +139,9 @@ public class APKExpansionPolicy implements Policy {
             setRetryCount(mRetryCount + 1);
         }
 
+        // Update server policy data
+        Map<String, String> extras = decodeExtras(rawData);
         if (response == Policy.LICENSED) {
-            // Update server policy data
-            Map<String, String> extras = decodeExtras(rawData.extra);
             mLastResponse = response;
             setValidityTimestamp(Long.toString(System.currentTimeMillis() + MILLIS_PER_MINUTE));
             Set<String> keys = extras.keySet();
@@ -163,6 +168,7 @@ public class APKExpansionPolicy implements Policy {
             setValidityTimestamp(DEFAULT_VALIDITY_TIMESTAMP);
             setRetryUntil(DEFAULT_RETRY_UNTIL);
             setMaxRetries(DEFAULT_MAX_RETRIES);
+            setLicensingUrl(extras.get("LU"));
         }
 
         setLastResponse(response);
@@ -276,6 +282,20 @@ public class APKExpansionPolicy implements Policy {
     }
 
     /**
+     * Set the licensing URL that displays a Play Store UI for the user to regain app access.
+     *
+     * @param url the LU string received
+     */
+    private void setLicensingUrl(String url) {
+        mLicensingUrl = url;
+        mPreferences.putString(PREF_LICENSING_URL, url);
+    }
+
+    public String getLicensingUrl() {
+        return mLicensingUrl;
+    }
+
+    /**
      * Gets the count of expansion URLs. Since expansionURLs are not committed
      * to preferences, this will return zero if there has been no LVL fetch
      * in the current session.
@@ -372,10 +392,15 @@ public class APKExpansionPolicy implements Policy {
         return false;
     }
 
-    private Map<String, String> decodeExtras(String extras) {
+    private Map<String, String> decodeExtras(
+        com.google.android.vending.licensing.ResponseData rawData) {
         Map<String, String> results = new HashMap<String, String>();
+        if (rawData == null) {
+            return results;
+        }
+
         try {
-            URI rawExtras = new URI("?" + extras);
+            URI rawExtras = new URI("?" + rawData.extra);
             URIQueryDecoder.DecodeQuery(rawExtras, results);
         } catch (URISyntaxException e) {
             Log.w(TAG, "Invalid syntax error while decoding extras data from server.");

--- a/lvl_library/src/main/java/com/google/android/vending/licensing/APKExpansionPolicy.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/APKExpansionPolicy.java
@@ -143,6 +143,8 @@ public class APKExpansionPolicy implements Policy {
         Map<String, String> extras = decodeExtras(rawData);
         if (response == Policy.LICENSED) {
             mLastResponse = response;
+            // Reset the licensing URL since it is only applicable for NOT_LICENSED responses.
+            setLicensingUrl(null);
             setValidityTimestamp(Long.toString(System.currentTimeMillis() + MILLIS_PER_MINUTE));
             Set<String> keys = extras.keySet();
             for (String key : keys) {
@@ -164,10 +166,11 @@ public class APKExpansionPolicy implements Policy {
                 }
             }
         } else if (response == Policy.NOT_LICENSED) {
-            // Clear out stale policy data
+            // Clear out stale retry params
             setValidityTimestamp(DEFAULT_VALIDITY_TIMESTAMP);
             setRetryUntil(DEFAULT_RETRY_UNTIL);
             setMaxRetries(DEFAULT_MAX_RETRIES);
+            // Update the licensing URL
             setLicensingUrl(extras.get("LU"));
         }
 

--- a/lvl_library/src/main/java/com/google/android/vending/licensing/LicenseChecker.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/LicenseChecker.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.net.Uri;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.IBinder;
@@ -193,6 +194,20 @@ public class LicenseChecker implements ServiceConnection {
                 runChecks();
             }
         }
+    }
+
+    /**
+     * Triggers the last deep link licensing URL returned from the server, which redirects users to a
+     * page which enables them to gain access to the app. If no such URL is returned by the server, it
+     * will go to the details page of the app in the Play Store.
+     */
+    public void followLastLicensingUrl(Context context) {
+        String licensingUrl = mPolicy.getLicensingUrl();
+        if (licensingUrl == null) {
+            licensingUrl = "https://play.google.com/store/apps/details?id=" + context.getPackageName();
+        }
+        Intent marketIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(licensingUrl));
+        context.startActivity(marketIntent);
     }
 
     private void runChecks() {

--- a/lvl_library/src/main/java/com/google/android/vending/licensing/Policy.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/Policy.java
@@ -56,4 +56,10 @@ public interface Policy {
      * Check if the user should be allowed access to the application.
      */
     boolean allowAccess();
+
+    /**
+     * Gets the licensing URL returned by the server that can enable access for unlicensed apps (e.g.
+     * buy app on the Play Store).
+     */
+    String getLicensingUrl();
 }

--- a/lvl_library/src/main/java/com/google/android/vending/licensing/ServerManagedPolicy.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/ServerManagedPolicy.java
@@ -115,14 +115,17 @@ public class ServerManagedPolicy implements Policy {
         Map<String, String> extras = decodeExtras(rawData);
         if (response == Policy.LICENSED) {
             mLastResponse = response;
+            // Reset the licensing URL since it is only applicable for NOT_LICENSED responses.
+            setLicensingUrl(null);
             setValidityTimestamp(extras.get("VT"));
             setRetryUntil(extras.get("GT"));
             setMaxRetries(extras.get("GR"));
         } else if (response == Policy.NOT_LICENSED) {
-            // Clear out stale policy data
+            // Clear out stale retry params
             setValidityTimestamp(DEFAULT_VALIDITY_TIMESTAMP);
             setRetryUntil(DEFAULT_RETRY_UNTIL);
             setMaxRetries(DEFAULT_MAX_RETRIES);
+            // Update the licensing URL
             setLicensingUrl(extras.get("LU"));
         }
 

--- a/lvl_library/src/main/java/com/google/android/vending/licensing/ServerManagedPolicy.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/ServerManagedPolicy.java
@@ -30,8 +30,8 @@ import com.google.android.vending.licensing.util.URIQueryDecoder;
 /**
  * Default policy. All policy decisions are based off of response data received
  * from the licensing service. Specifically, the licensing server sends the
- * following information: response validity period, error retry period, and
- * error retry count.
+ * following information: response validity period, error retry period,
+ * error retry count and a URL for restoring app access in unlicensed cases.
  * <p>
  * These values will vary based on the the way the application is configured in
  * the Google Play publishing console, such as whether the application is
@@ -50,6 +50,7 @@ public class ServerManagedPolicy implements Policy {
     private static final String PREF_RETRY_UNTIL = "retryUntil";
     private static final String PREF_MAX_RETRIES = "maxRetries";
     private static final String PREF_RETRY_COUNT = "retryCount";
+    private static final String PREF_LICENSING_URL = "licensingUrl";
     private static final String DEFAULT_VALIDITY_TIMESTAMP = "0";
     private static final String DEFAULT_RETRY_UNTIL = "0";
     private static final String DEFAULT_MAX_RETRIES = "0";
@@ -63,6 +64,7 @@ public class ServerManagedPolicy implements Policy {
     private long mRetryCount;
     private long mLastResponseTime = 0;
     private int mLastResponse;
+    private String mLicensingUrl;
     private PreferenceObfuscator mPreferences;
 
     /**
@@ -80,6 +82,7 @@ public class ServerManagedPolicy implements Policy {
         mRetryUntil = Long.parseLong(mPreferences.getString(PREF_RETRY_UNTIL, DEFAULT_RETRY_UNTIL));
         mMaxRetries = Long.parseLong(mPreferences.getString(PREF_MAX_RETRIES, DEFAULT_MAX_RETRIES));
         mRetryCount = Long.parseLong(mPreferences.getString(PREF_RETRY_COUNT, DEFAULT_RETRY_COUNT));
+        mLicensingUrl = mPreferences.getString(PREF_LICENSING_URL, null);
     }
 
     /**
@@ -88,10 +91,12 @@ public class ServerManagedPolicy implements Policy {
      * This data will be used for computing future policy decisions. The
      * following parameters are processed:
      * <ul>
-     * <li>VT: the timestamp that the client should consider the response
-     *   valid until
+     * <li>VT: the timestamp that the client should consider the response valid
+     * until
      * <li>GT: the timestamp that the client should ignore retry errors until
      * <li>GR: the number of retry errors that the client should ignore
+     * <li>LU: a deep link URL that can enable access for unlicensed apps (e.g.
+     * buy app on the Play Store)
      * </ul>
      *
      * @param response the result from validating the server response
@@ -106,9 +111,9 @@ public class ServerManagedPolicy implements Policy {
             setRetryCount(mRetryCount + 1);
         }
 
+        // Update server policy data
+        Map<String, String> extras = decodeExtras(rawData);
         if (response == Policy.LICENSED) {
-            // Update server policy data
-            Map<String, String> extras = decodeExtras(rawData.extra);
             mLastResponse = response;
             setValidityTimestamp(extras.get("VT"));
             setRetryUntil(extras.get("GT"));
@@ -118,6 +123,7 @@ public class ServerManagedPolicy implements Policy {
             setValidityTimestamp(DEFAULT_VALIDITY_TIMESTAMP);
             setRetryUntil(DEFAULT_RETRY_UNTIL);
             setMaxRetries(DEFAULT_MAX_RETRIES);
+            setLicensingUrl(extras.get("LU"));
         }
 
         setLastResponse(response);
@@ -231,6 +237,21 @@ public class ServerManagedPolicy implements Policy {
     }
 
     /**
+     * Set the license URL value (LU) as received from the server and add to preferences. You must
+     * manually call PreferenceObfuscator.commit() to commit these changes to disk.
+     *
+     * @param url the LU string received
+     */
+    private void setLicensingUrl(String url) {
+        mLicensingUrl = url;
+        mPreferences.putString(PREF_LICENSING_URL, url);
+    }
+
+    public String getLicensingUrl() {
+        return mLicensingUrl;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * This implementation allows access if either:<br>
@@ -257,10 +278,15 @@ public class ServerManagedPolicy implements Policy {
         return false;
     }
 
-    private Map<String, String> decodeExtras(String extras) {
+    private Map<String, String> decodeExtras(
+        com.google.android.vending.licensing.ResponseData rawData) {
         Map<String, String> results = new HashMap<String, String>();
+        if (rawData == null) {
+            return results;
+        }
+
         try {
-            URI rawExtras = new URI("?" + extras);
+            URI rawExtras = new URI("?" + rawData.extra);
             URIQueryDecoder.DecodeQuery(rawExtras, results);
         } catch (URISyntaxException e) {
             Log.w(TAG, "Invalid syntax error while decoding extras data from server.");

--- a/lvl_library/src/main/java/com/google/android/vending/licensing/StrictPolicy.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/StrictPolicy.java
@@ -16,6 +16,13 @@
 
 package com.google.android.vending.licensing;
 
+import android.util.Log;
+import com.google.android.vending.licensing.util.URIQueryDecoder;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Non-caching policy. All requests will be sent to the licensing service,
  * and no local caching is performed.
@@ -26,28 +33,38 @@ package com.google.android.vending.licensing;
  * weigh the risks of using this Policy over one which implements caching,
  * such as ServerManagedPolicy.
  * <p>
- * Access to the application is only allowed if a LICESNED response is.
+ * Access to the application is only allowed if a LICENSED response is.
  * received. All other responses (including RETRY) will deny access.
  */
 public class StrictPolicy implements Policy {
 
+    private static final String TAG = "StrictPolicy";
+
     private int mLastResponse;
+    private String mLicensingUrl;
 
     public StrictPolicy() {
         // Set default policy. This will force the application to check the policy on launch.
         mLastResponse = Policy.RETRY;
+        mLicensingUrl = null;
     }
 
     /**
      * Process a new response from the license server. Since we aren't
      * performing any caching, this equates to reading the LicenseResponse.
-     * Any ResponseData provided is ignored.
+     * Any cache-related ResponseData is ignored, but the licensing URL
+     * extra is still extracted in cases where the app is unlicensed.
      *
      * @param response the result from validating the server response
      * @param rawData the raw server response data
      */
     public void processServerResponse(int response, ResponseData rawData) {
         mLastResponse = response;
+
+        if (response == Policy.NOT_LICENSED) {
+            Map<String, String> extras = decodeExtras(rawData);
+            mLicensingUrl = extras.get("LU");
+        }
     }
 
     /**
@@ -58,6 +75,26 @@ public class StrictPolicy implements Policy {
      */
     public boolean allowAccess() {
         return (mLastResponse == Policy.LICENSED);
+    }
+
+    public String getLicensingUrl() {
+        return mLicensingUrl;
+    }
+
+    private Map<String, String> decodeExtras(
+        com.google.android.vending.licensing.ResponseData rawData) {
+        Map<String, String> results = new HashMap<String, String>();
+        if (rawData == null) {
+            return results;
+        }
+
+        try {
+            URI rawExtras = new URI("?" + rawData.extra);
+            URIQueryDecoder.DecodeQuery(rawExtras, results);
+        } catch (URISyntaxException e) {
+            Log.w(TAG, "Invalid syntax error while decoding extras data from server.");
+        }
+        return results;
     }
 
 }

--- a/lvl_sample/src/androidTest/java/com/google/android/vending/licensing/StrictPolicyTest.java
+++ b/lvl_sample/src/androidTest/java/com/google/android/vending/licensing/StrictPolicyTest.java
@@ -24,6 +24,7 @@ import com.google.android.vending.licensing.StrictPolicy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -57,14 +58,21 @@ public class StrictPolicyTest {
 
     /**
      * Verify that after receiving a NOT_LICENSED response, the policy denies
-     * access.
+     * access and extracts the licensing URL from the response.
      */
     @Test
     public void notLicensedResponse() {
         StrictPolicy p = new StrictPolicy();
-        p.processServerResponse(Policy.NOT_LICENSED, null);
+
+        String sampleResponse = "0|1579380448|com.example.android.market.licensing|1|" +
+            "ADf8I4ajjgc1P5ZI1S1DN/YIPIUNPECLrg==|1279578835423:" +
+            "LU=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dcom.example.android.market.licensing";
+        p.processServerResponse(Policy.NOT_LICENSED, ResponseData.parse(sampleResponse));
         boolean result = p.allowAccess();
         assertFalse(result);
+        assertEquals(
+            "https://play.google.com/store/apps/details?id=com.example.android.market.licensing",
+            p.getLicensingUrl());
     }
 
     /**

--- a/lvl_sample/src/main/java/com/example/google/play/licensing/MainActivity.java
+++ b/lvl_sample/src/main/java/com/example/google/play/licensing/MainActivity.java
@@ -90,7 +90,7 @@ public class MainActivity extends Activity {
         // Construct the LicenseChecker with a policy.
         mChecker = new LicenseChecker(
             this, new ServerManagedPolicy(this,
-                new AESObfuscator(SALT, getPackageName(), deviceId)),
+            new AESObfuscator(SALT, getPackageName(), deviceId)),
             BASE64_PUBLIC_KEY);
         doCheck();
     }
@@ -100,15 +100,14 @@ public class MainActivity extends Activity {
         return new AlertDialog.Builder(this)
             .setTitle(R.string.unlicensed_dialog_title)
             .setMessage(bRetry ? R.string.unlicensed_dialog_retry_body : R.string.unlicensed_dialog_body)
-            .setPositiveButton(bRetry ? R.string.retry_button : R.string.buy_button, new DialogInterface.OnClickListener() {
+            .setPositiveButton(bRetry ? R.string.retry_button : R.string.restore_access_button,
+                new DialogInterface.OnClickListener() {
                 boolean mRetry = bRetry;
                 public void onClick(DialogInterface dialog, int which) {
                     if ( mRetry ) {
                         doCheck();
                     } else {
-                        Intent marketIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(
-                                "http://market.android.com/details?id=" + getPackageName()));
-                            startActivity(marketIntent);
+                        mChecker.followLastLicensingUrl(MainActivity.this);
                     }
                 }
             })
@@ -167,7 +166,8 @@ public class MainActivity extends Activity {
             // the app should inform the user of their unlicensed ways
             // and then either shut down the app or limit the user to a
             // restricted set of features.
-            // In this example, we show a dialog that takes the user to Market.
+            // In this example, we show a dialog that takes the user to a deep
+            // link returned by the license checker.
             // If the reason for the lack of license is that the service is
             // unavailable or there is another problem, we display a
             // retry button on the dialog and a different message.

--- a/lvl_sample/src/main/res/values/strings.xml
+++ b/lvl_sample/src/main/res/values/strings.xml
@@ -21,13 +21,13 @@
     <string name="checking_license">Checking license...</string>
     <string name="dont_allow">Don\'t allow the user access</string>
     <string name="allow">Allow the user access</string>
-    <string name="application_error">Application error: %1$s</string>
+    <string name="application_error">Application error: %1$d</string>
 
     <!-- Unlicensed dialog messages -->
     <string name="unlicensed_dialog_title">Application not licensed</string>
-    <string name="unlicensed_dialog_body">This application is not licensed. Please purchase it from Android Market.</string>
+    <string name="unlicensed_dialog_body">This application is not licensed.</string>
     <string name="unlicensed_dialog_retry_body">Unable to validate license. Check to see if a network connection is available.</string>
-    <string name="buy_button">Buy app</string>
+    <string name="restore_access_button">Restore Access</string>
     <string name="retry_button">Retry</string>
     <string name="quit_button">Exit</string>
 </resources>


### PR DESCRIPTION
We want to start returning an "LU" extra from the server that is a Play Store deep link that can be used to restore access in cases where an app is unlicensed (ex. buy the app in the Play Store). Updating code to parse it from response.

Also, updating the sample app to demonstrate how the deep link can be triggered in developers license checking logic.