### PR TITLE
When following the URL returned by the server, explicitly set the Pla…

### DIFF
--- a/lvl_library/src/main/java/com/google/android/vending/licensing/LicenseChecker.java
+++ b/lvl_library/src/main/java/com/google/android/vending/licensing/LicenseChecker.java
@@ -207,6 +207,7 @@ public class LicenseChecker implements ServiceConnection {
             licensingUrl = "https://play.google.com/store/apps/details?id=" + context.getPackageName();
         }
         Intent marketIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(licensingUrl));
+        marketIntent.setPackage("com.android.vending");
         context.startActivity(marketIntent);
     }
 


### PR DESCRIPTION
…y store package name in the intent to prevent a disambiguation dialog.